### PR TITLE
Add a null check to catch missing metadata

### DIFF
--- a/PlutoIPTV/index.js
+++ b/PlutoIPTV/index.js
@@ -203,7 +203,7 @@ ${m3uUrl}
           })
 
           let airingArt
-          if (isMovie) {
+          if (isMovie && null != programme.episode.poster) {
             airingArt = programme.episode.poster.path
           } else {
             airingArt = programme.episode.series.tile.path.replace("w=660", "w=900").replace("h=660", "h=900")


### PR DESCRIPTION
I ran into a failure when running the container on my machine and traced it back to this line of code. Adding a quick null check fixes the failure. 
```
> /usr/src/app/index.js:207
> airingArt = programme.episode.poster.path
> ^
> 
> TypeError: Cannot read property 'path' of undefined
> at /usr/src/app/index.js:207:50
> at Array.forEach (<anonymous>)
> at /usr/src/app/index.js:182:27
> at Array.forEach (<anonymous>)
> at /usr/src/app/index.js:165:12
> at Object.grabJSON (/usr/src/app/index.js:33:9)
> at Object.<anonymous> (/usr/src/app/index.js:99:11)
> at Module._compile (internal/modules/cjs/loader.js:1063:30)
> at Object.Module._extensions..js (internal/modules/cjs/loader.js:1103:10)
> at Module.load (internal/modules/cjs/loader.js:914:32)
```