### PR TITLE
Add Support to build APK for LXC Containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -51,3 +51,41 @@ Next, set the provider for your new source and choose custom URL.
 Finally, enter your EPG xml url and set it to refresh every 6 hours.
 
 <img src=".github/3.png" width="500px"/>
+
+## Alpine Linux Package
+
+For those of you who use LXC Containers without Docker, there also is an option to generate an untrusted APK file for install to as many containers as needed.  Here are the steps:
+
+1. Clone the git repo locally
+2. cd [root of the git repo]
+3. Run build script (this will run Docker to generate the APK)
+```
+apk/build
+```
+4. copy the 2 APKs from apk/outputs to your LXC container
+```
+# ls -la apk/outputs/src/aarch64/*.apk
+apk/outputs//src/aarch64/pluto-for-channels-1.2.15-r0.apk		apk/outputs//src/aarch64/pluto-for-channels-openrc-1.2.15-r0.apk
+# scp apk/outputs/src/aarch64/*.apk user@lxc-container:
+```
+5. Login to the LXC Container
+6. Install the APKs
+```
+# apk add --allow-untrusted ./pluto-for-channels-1.2.15-r0.apk ./pluto-for-channels-openrc-1.2.15-r0.apk
+```
+7. Customize as you see fit, Environment variables for the daemon are in /etc/conf.d/pluto-for-channels
+8. Enable the service
+```
+/usr/src/app/enable
+```
+
+### If you want to uninstall, do the following:
+
+1. Disable the service
+```
+/usr/src/app/disable
+```
+2. Uninstall the packges:
+```
+# apk del pluto-for-channels pluto-for-channels-openrc
+```

--- a/apk/.gitignore
+++ b/apk/.gitignore
@@ -1,0 +1,2 @@
+outputs
+outputs/*

--- a/apk/Dockerfile
+++ b/apk/Dockerfile
@@ -1,0 +1,40 @@
+FROM alpine:3.14 as builder
+
+# Bring in the dependencies
+RUN apk add --no-cache --update-cache alpine-sdk doas nginx libuv nodejs-current npm yarn 
+
+# Add a user to build the APK
+RUN adduser -D builduser && \
+    addgroup builduser abuild
+
+# Give the user permissions
+RUN echo "permit keepenv :builduser" > /etc/doas.conf
+
+# Switch to builduser
+USER builduser
+WORKDIR /home/builduser
+
+# Setup abuild config
+RUN mkdir -p ~/.abuild && \
+    echo 'PACKAGER="Build User <build@example.com>"' > ~/.abuild/abuild.conf && \
+    echo 'BUILDROOT=/var/cache/distfiles' >> ~/.abuild/abuild.conf
+
+# Generate signing keypair (each build will be different)
+RUN abuild-keygen -a -n
+
+# Copy source 
+COPY --chown=builduser:builduser apk/package /home/builduser/src/package
+COPY --chown=builduser:builduser VERSION /home/builduser/src/package
+COPY --chown=builduser:builduser index.html /home/builduser/src/package
+COPY --chown=builduser:builduser entrypoint.sh /home/builduser/src/package
+COPY --chown=builduser:builduser PlutoIPTV/* /home/builduser/src/package/PlutoIPTV/
+
+# Build package
+WORKDIR /home/builduser/src/package
+RUN abuild -v -rF
+
+FROM alpine:3.14
+
+# Copy the built packages into /output inside this final image
+COPY --from=builder /home/builduser/packages /output
+COPY --from=builder /home/builduser/.abuild /output

--- a/apk/build
+++ b/apk/build
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+if [ ! -f VERSION ]; then
+  echo "Not building from the root of the git repo"
+  exit -1
+fi 
+
+rm -rf apk/outputs
+
+docker build --no-cache -f apk/Dockerfile -t pluto-for-channels-builder ${PWD}
+docker create --name builder pluto-for-channels-builder
+docker cp builder:/output ./apk/outputs
+docker rm builder

--- a/apk/package/APKBUILD
+++ b/apk/package/APKBUILD
@@ -1,0 +1,43 @@
+pkgname=pluto-for-channels
+pkgver=1.2.15
+pkgrel=0
+pkgdesc="Pluto for Channels"
+url="https://github.com/maddox/pluto-for-channels"
+license="MIT"
+depends="nginx libuv nodejs-current npm yarn curl"
+depends_dev=""
+makedepends="$depends_dev"
+install="pluto-for-channels.post-install pluto-for-channels.pre-deinstall"
+arch=noarch
+
+subpackages="$pkgname-openrc"
+depends_openrc="pluto-for-channels"
+
+prepare() {
+    default_prepare
+
+	mkdir -p "$srcdir/$pkgname-$pkgver"
+    cp -r "$startdir/VERSION" "$srcdir/$pkgname-$pkgver"
+    cp -r "$startdir/entrypoint.sh" "$srcdir/$pkgname-$pkgver"
+    cp -r "$startdir/index.html" "$srcdir/$pkgname-$pkgver"
+    cp -r "$startdir/PlutoIPTV/"* "$srcdir/$pkgname-$pkgver"
+}
+
+package() {
+    cd "$builddir"
+    install -Dm755 /dev/null "$pkgdir"/etc/$pkgname/config.json
+
+    # copy app into /usr/share
+    install -dm755 "$pkgdir"/usr/src/app
+    cp -r . "$pkgdir"/usr/src/app
+	install -m644 "$startdir"/nginx.conf "$pkgdir"/usr/src/app
+	install -m755 "$startdir"/enable "$pkgdir"/usr/src/app
+	install -m755 "$startdir"/disable "$pkgdir"/usr/src/app
+
+    install -dm755 "$pkgdir"/var/www/html
+
+    
+    # init scripts
+    install -Dm755 "$startdir"/pluto.initd "$pkgdir"/etc/init.d/$pkgname
+    install -Dm644 "$startdir"/pluto.confd "$pkgdir"/etc/conf.d/$pkgname
+}

--- a/apk/package/disable
+++ b/apk/package/disable
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+rc-service pluto-for-channels stop
+rc-service nginx stop
+
+rc-update del pluto-for-channels
+rc-update del nginx

--- a/apk/package/enable
+++ b/apk/package/enable
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+rc-update add nginx
+rc-update add pluto-for-channels
+
+rc-service nginx start
+rc-service pluto-for-channels start

--- a/apk/package/nginx.conf
+++ b/apk/package/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+
+    root /var/www/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+
+    # Optional: prevent listing hidden files
+    location ~ /\. {
+        deny all;
+    }
+}

--- a/apk/package/pluto-for-channels.post-install
+++ b/apk/package/pluto-for-channels.post-install
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+cd /usr/src/app
+yarn --production --no-progress
+rm -rf /tmp/*
+
+cp nginx.conf /etc/nginx/http.d/default.conf
+
+exit 0

--- a/apk/package/pluto-for-channels.pre-deinstall
+++ b/apk/package/pluto-for-channels.pre-deinstall
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+rm -rf /var/log/pluto.err /var/log/pluto.log
+
+cd /usr/src/app
+rm -rf node_modules cache.json cache.json epg.xml
+
+exit 0

--- a/apk/package/pluto.confd
+++ b/apk/package/pluto.confd
@@ -1,0 +1,3 @@
+# Uncomment setting and customize as needed
+# VERSION=MAIN
+# START=8000

--- a/apk/package/pluto.initd
+++ b/apk/package/pluto.initd
@@ -1,0 +1,22 @@
+#!/sbin/openrc-run
+
+name="pluto-for-channels"
+command="/usr/src/app/entrypoint.sh"
+command_user="root:root"
+pidfile="/run/$RC_SVCNAME.pid"
+command_background="yes"
+output_log="/var/log/pluto.log"
+error_log="/var/log/pluto.err"
+start_stop_daemon_args="--env START_NGINX=NO --env NGINX_ROOT=/var/www/html"
+
+if [ "${VERSION}" != "" ]; then
+start_stop_daemon_args="${start_stop_daemon_args} --env VERSION=${VERSION}"
+fi
+if [ "${START}" != "" ]; then
+start_stop_daemon_args="${start_stop_daemon_args} --env START=${START}"
+fi
+
+depend() {
+    need net
+    use dns
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,9 +2,18 @@
 
 cd /usr/src/app
 
+if [ ${START_NGINX=YES} == "YES" ]; then
 nginx
+fi
 
+if [ ${NGINX_ROOT} == "" ]; then
 NGINX_ROOT=/usr/share/nginx/html
+fi
+
+if [ ! -d ${NGINX_ROOT} ]; then
+  echo "${NGINX_ROOT} is not a directory"
+  exit 1
+fi
 
 get_latest_release() {
   curl --silent "https://api.github.com/repos/maddox/pluto-for-channels/releases/latest" |


### PR DESCRIPTION
Hopefully this is interesting to you.   I am upgrading to Proxmox and LXCs make my life easier than Docker from a networking perspective (I have 3 different Pluto countries running)

Here are some items that I added, let me know what you think:

1. Updated Readme with some directions
2. Created Dockerfile to build an APK for Pluto-For-Channels
3. Created build script to execute the build
4. Updated entrypoint.sh to all for nginx to be external and configurable
5. updates .gitignore to ignore MacOS .DS_Store as I work on Mac as my primary desktop.