### PR TITLE
Add `tvg-chno` alongside `channel-number`.

### DIFF
--- a/PlutoIPTV/index.js
+++ b/PlutoIPTV/index.js
@@ -396,7 +396,7 @@ function processChannels(version, list) {
 
       m3u8 =
         m3u8 +
-        `#EXTINF:0 channel-id="${slug}" channel-number="${channelNumber}" tvg-logo="${logo}" tvc-guide-art="${art}" tvc-guide-title="${name}" tvc-guide-description="${guideDescription}" group-title="${group}", ${name}
+        `#EXTINF:0 channel-id="${slug}" tvg-chno="${channelNumber}" channel-number="${channelNumber}" tvg-logo="${logo}" tvc-guide-art="${art}" tvc-guide-title="${name}" tvc-guide-description="${guideDescription}" group-title="${group}", ${name}
 ${m3uUrl}
 
 `;


### PR DESCRIPTION
Jellyfin doesn't recognise the latter, only the former.

Resolves #32.